### PR TITLE
Escape and sanitize queries

### DIFF
--- a/force-app/main/default/classes/SoslInvocableMethod.cls
+++ b/force-app/main/default/classes/SoslInvocableMethod.cls
@@ -10,8 +10,19 @@ public with sharing class SoslInvocableMethod {
 
             System.debug('### SoslInvocableMethod execute req >>>'+req);
 
+            // Sanitize and Escape our queries
+            List<String> escapedQueries = new List<String>();
+            for (String query : req.queries) {
+                String escaped = escapeSoslReservedChars(query);
+                escaped = String.escapeSingleQuotes(escaped);
+                escapedQueries.add(escaped);
+            }
+
+            System.debug('### SoslInvocableMethod Escaped Queries >>>'+ escapedQueries);
             // Build Query String
-            String queryString = '\'' + String.join(req.queries, ' OR ') + '\'';
+
+            String queryString = '\'' + String.join(escapedQueries, ' OR ') + '\'';
+
             System.debug('### SoslInvocableMethod execute queryString >>>'+queryString);
 
             // Build SOSL
@@ -25,7 +36,7 @@ public with sharing class SoslInvocableMethod {
 
             // Execute the SOSL search
             Search.SearchResults searchResults = Search.find(sosl);
-            
+
             // Get the list of SObject results
             List<Search.SearchResult> recordList = searchResults.get(req.objectAPIName);
 
@@ -35,13 +46,36 @@ public with sharing class SoslInvocableMethod {
             for (Search.SearchResult searchResult : recordList) {
                 SObject record = searchResult.getSObject();
                 res.recordIds.add(record.Id);
-            } 
+            }
 
             // Add the response
             response.add(res);
         }
 
         return response;
+    }
+
+    private static String escapeSoslReservedChars(String input) {
+        if (String.isBlank(input)) {
+            return input;
+        }
+        return input
+            .replace('\\', '\\\\')  // Backslash must be first
+            .replace('?', '\\?')
+            .replace('*', '\\*')
+            .replace('&', '\\&')
+            .replace('|', '\\|')
+            .replace('!', '\\!')
+            .replace('{', '\\{')
+            .replace('}', '\\}')
+            .replace('[', '\\[')
+            .replace(']', '\\]')
+            .replace('(', '\\(')
+            .replace(')', '\\)')
+            .replace(':', '\\:')
+            .replace('^', '\\^')
+            .replace('~', '\\~')
+            .replace('"', '\\"');
     }
 
     public class Request {

--- a/force-app/main/default/classes/SoslInvocableMethodTest.cls
+++ b/force-app/main/default/classes/SoslInvocableMethodTest.cls
@@ -15,14 +15,82 @@ private class SoslInvocableMethodTest {
         request.scope = 'ALL FIELDS';
         request.whereClause = 'Type = \'Test\'';
         Test.setFixedSearchResults(new Id[]{accounts[2].Id});
+        
         Test.startTest();
         List<SoslInvocableMethod.Result> results = SoslInvocableMethod.execute(
             new List<SoslInvocableMethod.Request>{ request }
         );
         Test.stopTest();
+        
         System.assertEquals(3, [SELECT COUNT() FROM Account], 'Expected to have 3 accounts');
         System.assertEquals(1, results.size(), 'Expected only 1 result collection returned');
         System.assertEquals(1, results[0].recordIds.size(), 'Expected only 1 record Id returned');
     }
 
+    @IsTest
+    static void testExecuteWithReservedChars() {
+        // Setup data
+        Account acc = new Account(Name='Reserved Chars Test');
+        insert acc;
+
+        SoslInvocableMethod.Request request = new SoslInvocableMethod.Request();
+        request.objectAPIName = 'Account';
+        
+        // Add strings containing SOSL reserved characters.
+        // If these are not escaped, Search.find() will throw an exception
+        request.queries = new List<String>{
+            'Test?',    // Wildcard
+            'Test*',    // Wildcard
+            'A & B',    // Logical AND
+            'A | B',    // Logical OR
+            '!Test',    // Logical NOT
+            '{Group}',  // Grouping
+            '[Group]',  // Grouping
+            '(Group)',  // Grouping
+            'Name:Test',// Field reference
+            'Boost^',   // Boosting
+            'Fuzzy~',   // Fuzzy
+            'Quote"',   // Double Quotes
+            'Back\\Slash' // Backslash
+        };
+        request.scope = 'ALL FIELDS';
+        
+        // mock the result because SOSL doesn't actually search in tests
+        Test.setFixedSearchResults(new Id[]{acc.Id});
+        
+        Test.startTest();
+        // This should verify that the query string syntax is valid after our escaping process
+        List<SoslInvocableMethod.Result> results = SoslInvocableMethod.execute(
+            new List<SoslInvocableMethod.Request>{ request }
+        );
+        Test.stopTest();
+        
+        System.assertEquals(1, results.size(), 'Expected 1 result collection');
+        System.assertEquals(1, results[0].recordIds.size(), 'Expected record to be returned despite reserved characters');
+    }
+
+    @IsTest
+    static void testExecuteWithSingleQuotes() {
+        // Setup data
+        Account acc = new Account(Name='O\'Reilly');
+        insert acc;
+
+        SoslInvocableMethod.Request request = new SoslInvocableMethod.Request();
+        request.objectAPIName = 'Account';
+        
+        // Input specifically testing single quote escaping (Injection prevention)
+        request.queries = new List<String>{'O\'Reilly'}; 
+        request.scope = 'ALL FIELDS';
+        
+        Test.setFixedSearchResults(new Id[]{acc.Id});
+        
+        Test.startTest();
+        List<SoslInvocableMethod.Result> results = SoslInvocableMethod.execute(
+            new List<SoslInvocableMethod.Request>{ request }
+        );
+        Test.stopTest();
+        
+        System.assertEquals(1, results.size(), 'Should handle single quotes without error');
+        System.assertEquals(acc.Id, results[0].recordIds[0], 'Should return the mocked ID');
+    }
 }


### PR DESCRIPTION
Escape single quotes to prevent SOSL injection.

Escape reserved SOSL characters

This should solve #1 and help reduce the SOSL Injection threat.