### PR TITLE
Fix SOSL escaping for special characters & bump install package id

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This is a basic SOSL apex invokable class, made primarily for use in flows. It w
 
 You can install the package from these links:
 
-[Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2w000004kaeW)
+[Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2w000004kaeb)
 
-[Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2w000004kaeW)
+[Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2w000004kaeb)
 
 ## What It Does
 

--- a/force-app/main/default/classes/SoslInvocableMethod.cls
+++ b/force-app/main/default/classes/SoslInvocableMethod.cls
@@ -59,23 +59,13 @@ public with sharing class SoslInvocableMethod {
         if (String.isBlank(input)) {
             return input;
         }
-        return input
-            .replace('\\', '\\\\')  // Backslash must be first
-            .replace('?', '\\?')
-            .replace('*', '\\*')
-            .replace('&', '\\&')
-            .replace('|', '\\|')
-            .replace('!', '\\!')
-            .replace('{', '\\{')
-            .replace('}', '\\}')
-            .replace('[', '\\[')
-            .replace(']', '\\]')
-            .replace('(', '\\(')
-            .replace(')', '\\)')
-            .replace(':', '\\:')
-            .replace('^', '\\^')
-            .replace('~', '\\~')
-            .replace('"', '\\"');
+        // In the single-quoted FIND 'term' form, the SOSL operator characters
+        // (? * & | ! { } [ ] ( ) : ^ ~ ") are treated as literal text, so they
+        // must NOT be backslash-escaped - doing so throws a QueryException:
+        // "Illegal character sequence '\&' in string literal". Only the backslash
+        // needs escaping here; the single quote is handled by the caller via
+        // String.escapeSingleQuotes.
+        return input.replace('\\', '\\\\');
     }
 
     public class Request {


### PR DESCRIPTION
## Summary

Two changes, rebased onto the current `master` (which already merged the initial escaping work in #2):

1. **Correct the special-character escaping (fixes #1).** Master's `escapeSoslReservedChars` backslash-escaped the SOSL operator characters (`& | ! { } [ ] ( ) : ^ ~ "`). In the single-quoted `FIND 'term'` form those characters are already literal, so escaping them produces an illegal string literal and throws:
   `System.QueryException: Invalid string literal '...'. Illegal character sequence '\&' in string literal.`
   The method is reduced to escaping only the backslash; the single quote is still handled by the existing `String.escapeSingleQuotes` call.

2. **Bump install links** in the README to the latest managed package version `04t2w000004kaeb`.

## Verification

Deployed to an org and ran the full test class — **3/3 passing**, including `testExecuteWithReservedChars`, which throws the complete reserved-character set (`A & B`, `!Test`, `{Group}`, `(Group)`, `Name:Test`, `Quote"`, `Back\Slash`, …) at the action and confirms no `QueryException` is raised.

